### PR TITLE
Remove usage of QTWEBKIT_VERSION_CHECK

### DIFF
--- a/webvfx/web_content.cpp
+++ b/webvfx/web_content.cpp
@@ -25,9 +25,7 @@ WebPage::WebPage(QObject* parent) : QWebPage(parent) {
 
     settings()->setAttribute(QWebSettings::SiteSpecificQuirksEnabled, false);
     settings()->setAttribute(QWebSettings::AcceleratedCompositingEnabled, true);
-#if (QTWEBKIT_VERSION >= QTWEBKIT_VERSION_CHECK(2, 2, 0))
     settings()->setAttribute(QWebSettings::WebGLEnabled, true);
-#endif
 }
 
 bool WebPage::shouldInterruptJavaScript() {


### PR DESCRIPTION
This macro was removed between qt 5.5.0 and 5.5.1 in qtwebkit commit
c3e58209d3601d86eeacde7abeeb39eb67a5aaf3