### PR TITLE
check pointers before using them

### DIFF
--- a/webvfx/effects_impl.cpp
+++ b/webvfx/effects_impl.cpp
@@ -84,9 +84,11 @@ bool EffectsImpl::initialize(const QString& fileName, int width, int height, Par
 
 void EffectsImpl::initializeComplete(bool result)
 {
-    QMutexLocker locker(mutex);
-    initializeResult = result;
-    waitCondition->wakeAll();
+    if (mutex && waitCondition) {
+        QMutexLocker locker(mutex);
+        initializeResult = result;
+        waitCondition->wakeAll();
+    }
 }
 
 void EffectsImpl::destroy()


### PR DESCRIPTION
Maybe fixes   https://github.com/mltframework/shotcut/issues/505

It looks weird to me that the `mutex` and `waitCondition` are created and deleted using local variable though. If they could be `NULL` in the callback function, they are potentially unsafe.